### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,31 @@ members = ["core0", "core1"]
 #     "metadata",
 # ] }
 
+[workspace.dependencies]
+chrono = { version = "0.4", default-features = false }
+cortex-m = "0.7.6"
+cortex-m-rt = "0.7.0"
+critical-section = "1.1"
+defmt = "0.3"
+defmt-rtt = "0.4"
+embassy-executor = { git = "https://github.com/esrlabs/embassy", branch = "feature/HSEM_SPI_FIX" }
+embassy-stm32 = { git = "https://github.com/esrlabs/embassy", branch = "feature/HSEM_SPI_FIX" }
+embassy-sync = { git = "https://github.com/esrlabs/embassy", branch = "feature/HSEM_SPI_FIX" }
+embassy-time = { git = "https://github.com/esrlabs/embassy", branch = "feature/HSEM_SPI_FIX" }
+embedded-hal = "0.2.6"
+embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = "1.0"
+embedded-io-async = "0.6.1"
+embedded-nal-async = "0.7.1"
+embedded-storage = "0.3.1"
+futures = { version = "0.3.17", default-features = false }
+heapless = { version = "0.8", default-features = false }
+micromath = "2.0.0"
+panic-probe = "0.3"
+rand_core = "0.6.3"
+static_cell = "2"
+stm32-fmc = "0.3.0"
+
 # cargo build/run
 [profile.dev]
 codegen-units = 1

--- a/core0/Cargo.toml
+++ b/core0/Cargo.toml
@@ -3,54 +3,27 @@ name = "core0"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-embassy-stm32 = { version = "0.1.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-    "stm32h747zi-cm7",
-    "time-driver-any",
-    "unstable-pac",
-    "chrono",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-sync = { version = "0.5.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-executor = { version = "0.5.0", git = "https://github.com/esrlabs/embassy", features = [
-    "task-arena-size-32768",
-    "arch-cortex-m",
-    "executor-thread",
-    "defmt",
-    "integrated-timers",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-time = { version = "0.3.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-    "defmt-timestamp-uptime",
-    "tick-hz-32_768",
-], branch = "feature/HSEM_SPI_FIX" }
-
-defmt = "0.3"
-defmt-rtt = "0.4"
-
-cortex-m = { version = "0.7.6", features = [
-    "inline-asm",
-    "critical-section-single-core",
-] }
-cortex-m-rt = "0.7.0"
-embedded-hal = "0.2.6"
-embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
-embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
-embedded-io-async = { version = "0.6.1" }
-panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = [
-    "async-await",
-] }
-heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
-critical-section = "1.1"
-micromath = "2.0.0"
-stm32-fmc = "0.3.0"
-embedded-storage = "0.3.1"
-static_cell = "2"
-chrono = { version = "^0.4", default-features = false }
+chrono = { workspace = true }
+cortex-m = { workspace = true, features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = { workspace = true }
+critical-section = { workspace = true }
+defmt = { workspace = true }
+defmt-rtt = { workspace = true }
+embassy-executor = { workspace = true, features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-stm32 = { workspace = true, features = ["defmt", "stm32h747zi-cm7", "time-driver-any", "unstable-pac", "chrono"] }
+embassy-sync = { workspace = true, features = ["defmt"] }
+embassy-time = { workspace = true, features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embedded-hal = { workspace = true }
+embedded-hal-1 = { workspace = true }
+embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
+embedded-nal-async = { workspace = true }
+embedded-storage = { workspace = true }
+futures = { workspace = true, features = ["async-await"] }
+heapless = { workspace = true }
+micromath = { workspace = true }
+panic-probe = { workspace = true, features = ["print-defmt"] }
+rand_core = { workspace = true }
+static_cell = { workspace = true }
+stm32-fmc = { workspace = true }

--- a/core1/Cargo.toml
+++ b/core1/Cargo.toml
@@ -3,55 +3,27 @@ name = "core1"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-embassy-stm32 = { version = "0.1.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-    "stm32h747zi-cm7",
-    "time-driver-any",
-    "memory-x",
-    "unstable-pac",
-    "chrono",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-sync = { version = "0.5.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-executor = { version = "0.5.0", git = "https://github.com/esrlabs/embassy", features = [
-    "task-arena-size-32768",
-    "arch-cortex-m",
-    "executor-thread",
-    "defmt",
-    "integrated-timers",
-], branch = "feature/HSEM_SPI_FIX" }
-embassy-time = { version = "0.3.0", git = "https://github.com/esrlabs/embassy", features = [
-    "defmt",
-    "defmt-timestamp-uptime",
-    "tick-hz-32_768",
-], branch = "feature/HSEM_SPI_FIX" }
-
-defmt = "0.3"
-defmt-rtt = "0.4"
-
-cortex-m = { version = "0.7.6", features = [
-    "inline-asm",
-    "critical-section-single-core",
-] }
-cortex-m-rt = "0.7.0"
-embedded-hal = "0.2.6"
-embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
-embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
-embedded-io-async = { version = "0.6.1" }
-panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = [
-    "async-await",
-] }
-heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
-critical-section = "1.1"
-micromath = "2.0.0"
-stm32-fmc = "0.3.0"
-embedded-storage = "0.3.1"
-static_cell = "2"
-chrono = { version = "^0.4", default-features = false }
+chrono = { workspace = true }
+cortex-m = { workspace = true, features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = { workspace = true }
+critical-section = { workspace = true }
+defmt = { workspace = true }
+defmt-rtt = { workspace = true }
+embassy-executor = { workspace = true, features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-stm32 = { workspace = true, features = ["defmt", "stm32h747zi-cm7", "time-driver-any", "memory-x", "unstable-pac", "chrono"] }
+embassy-sync = { workspace = true, features = ["defmt"] }
+embassy-time = { workspace = true, features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embedded-hal = { workspace = true }
+embedded-hal-1 = { workspace = true }
+embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
+embedded-nal-async = { workspace = true }
+embedded-storage = { workspace = true }
+futures = { workspace = true, features = ["async-await"] }
+heapless = { workspace = true }
+micromath = { workspace = true }
+panic-probe = { workspace = true, features = ["print-defmt"] }
+rand_core = { workspace = true }
+static_cell = { workspace = true }
+stm32-fmc = { workspace = true }


### PR DESCRIPTION
The dependency definition is repetitive and noisy. Use workspace dependencies to centralize the imports.

Apply cargo sort.