### PR TITLE
Add global HSEM object and shared memory sample

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -10,6 +10,11 @@
           "allTargets": false,
           "targets": "thumbv7em-none-eabihf"
         },
+        "linkedProjects": [
+          "./core0/Cargo.toml",
+          "./core1/Cargo.toml",
+          "./stm32h7hal-ext/Cargo.toml"
+        ],
         "inlayHints": {
           "maxLength": null,
           "lifetimeElisionHints": {

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,37 @@
+// Static tasks configuration.
+[
+  {
+    "label": "Build Core 0",
+    "command": "cargo build",
+    //"args": ["build"],
+    // Env overrides for the command, will be appended to the terminal's environment from the settings.
+    // "env": { "foo": "bar" },
+    // Current working directory to spawn the command into, defaults to current project root.
+    "cwd": "$ZED_WORKTREE_ROOT/core0",
+    // Whether to use a new terminal tab or reuse the existing one to spawn the process, defaults to `false`.
+    "use_new_terminal": false,
+    // Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish, defaults to `false`.
+    "allow_concurrent_runs": false
+    // What to do with the terminal pane and tab, after the command was started:
+    // * `always` — always show the terminal pane, add and focus the corresponding task's tab in it (default)
+    // * `never` — avoid changing current terminal pane focus, but still add/reuse the task's tab there
+    //"reveal": "always"
+  },
+  {
+    "label": "Build Core 1",
+    "command": "cargo build",
+    //"args": ["build"],
+    // Env overrides for the command, will be appended to the terminal's environment from the settings.
+    // "env": { "foo": "bar" },
+    // Current working directory to spawn the command into, defaults to current project root.
+    "cwd": "$ZED_WORKTREE_ROOT/core1",
+    // Whether to use a new terminal tab or reuse the existing one to spawn the process, defaults to `false`.
+    "use_new_terminal": false,
+    // Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish, defaults to `false`.
+    "allow_concurrent_runs": false
+    // What to do with the terminal pane and tab, after the command was started:
+    // * `always` — always show the terminal pane, add and focus the corresponding task's tab in it (default)
+    // * `never` — avoid changing current terminal pane focus, but still add/reuse the task's tab there
+    //"reveal": "always"
+  }
+]

--- a/core0/Cargo.lock
+++ b/core0/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -237,6 +238,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -250,6 +252,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.4.1"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -260,10 +263,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -274,6 +279,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
 ]
@@ -281,6 +287,7 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -324,6 +331,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -336,6 +344,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -353,6 +362,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "document-features",
 ]
@@ -360,10 +370,12 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
 ]

--- a/core0/Cargo.lock
+++ b/core0/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "micromath",
  "panic-probe",
  "rand_core",
+ "shared",
  "static_cell",
  "stm32-fmc",
  "stm32h7hal-ext",
@@ -220,7 +221,6 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -237,7 +237,6 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -251,7 +250,6 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.4.1"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -262,12 +260,10 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -278,7 +274,6 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
 ]
@@ -286,7 +281,6 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -330,7 +324,6 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -343,7 +336,6 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -361,7 +353,6 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "document-features",
 ]
@@ -369,12 +360,10 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
 ]
@@ -729,6 +718,10 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "shared"
+version = "0.1.0"
 
 [[package]]
 name = "stable_deref_trait"

--- a/core0/Cargo.toml
+++ b/core0/Cargo.toml
@@ -55,11 +55,11 @@ chrono = { version = "^0.4", default-features = false }
 stm32h7hal-ext = { version = "0.1.0", path = "../stm32h7hal-ext" }
 shared = { version = "0.1.0", path = "../shared" }
 
-[patch."https://github.com/esrlabs/embassy"]
-embassy-stm32 = { path = "../../embassy/embassy-stm32" }
-embassy-sync = { path = "../../embassy/embassy-sync" }
-embassy-executor = { path = "../../embassy/embassy-executor" }
-embassy-time = { path = "../../embassy/embassy-time" }
+# [patch."https://github.com/esrlabs/embassy"]
+# embassy-stm32 = { path = "../../embassy/embassy-stm32" }
+# embassy-sync = { path = "../../embassy/embassy-sync" }
+# embassy-executor = { path = "../../embassy/embassy-executor" }
+# embassy-time = { path = "../../embassy/embassy-time" }
 
 # cargo build/run
 [profile.dev]

--- a/core0/Cargo.toml
+++ b/core0/Cargo.toml
@@ -53,11 +53,13 @@ embedded-storage = "0.3.1"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false }
 stm32h7hal-ext = { version = "0.1.0", path = "../stm32h7hal-ext" }
-# [patch."https://github.com/esrlabs/embassy"]
-# embassy-stm32 = { path = "../../embassy/embassy-stm32" }
-# embassy-sync = { path = "../../embassy/embassy-sync" }
-# embassy-executor = { path = "../../embassy/embassy-executor" }
-# embassy-time = { path = "../../embassy/embassy-time" }
+shared = { version = "0.1.0", path = "../shared" }
+
+[patch."https://github.com/esrlabs/embassy"]
+embassy-stm32 = { path = "../../embassy/embassy-stm32" }
+embassy-sync = { path = "../../embassy/embassy-sync" }
+embassy-executor = { path = "../../embassy/embassy-executor" }
+embassy-time = { path = "../../embassy/embassy-time" }
 
 # cargo build/run
 [profile.dev]

--- a/core0/memory.x
+++ b/core0/memory.x
@@ -30,8 +30,8 @@ SECTIONS {
     *(.sram3 .sram3.*);
     . = ALIGN(4);
     } > SRAM3
-  .sram4 (NOLOAD) : ALIGN(4) {
-    *(.sram4 .sram4.*);
+  .shared (NOLOAD) : ALIGN(4) {
+    *(.sram4 .sram4.* .shared .shared.*);
     . = ALIGN(4);
     } > SRAM4
   .bsram (NOLOAD) : ALIGN(4) {

--- a/core0/src/main.rs
+++ b/core0/src/main.rs
@@ -30,17 +30,10 @@ static HSEM_INSTANCE: SyncUnsafeCell<Option<HardwareSemaphore<'static, HSEM>>> =
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     info!("Core0: STM32H755 Embassy HSEM Test.");
-    // let mut mailbox = unsafe { *shared::MAILBOX.get() as [u32; 10] };
-    // for i in 0..10 {
-    //     mailbox[i] = i as u32;
-    // }
-    // let m = unsafe { *shared::MAILBOX.get() as [u32; 10] };
-    // info!("Mailbox = {:?}", m);
-    unsafe { info!("Mailbox = {:?}", shared::MAILBOX) };
+
     unsafe {
         for i in 0..10 {
             shared::MAILBOX[i] = 0;
-            info!("Mailbox = 0x{:02x}", shared::MAILBOX[i]);
         }
     }
     // Wait for Core1 to be finished with its init
@@ -144,12 +137,11 @@ async fn set_core1_blink_delay(freq: u32) {
         retry -= 1;
     }
     if retry > 0 {
+        //let mut mailbox = *shared::MAILBOX.get() as [u32; 10];
         unsafe {
-            //let mut mailbox = *shared::MAILBOX.get() as [u32; 10];
-            unsafe {
-                shared::MAILBOX[0] = freq;
-            };
-        }
+            shared::MAILBOX[0] = freq;
+        };
+
         get_global_hsem().unlock(5, 0);
     } else {
         // Core1 has asquired the semaphore and is

--- a/core1/Cargo.lock
+++ b/core1/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -237,6 +238,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -250,6 +252,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.4.1"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -260,10 +263,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -274,6 +279,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
 ]
@@ -281,6 +287,7 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -324,6 +331,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -336,6 +344,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -353,6 +362,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "document-features",
 ]
@@ -360,10 +370,12 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
+source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#bbcf3e6b730df8a3a0bf28d24cf855bb01c07ce6"
 dependencies = [
  "defmt",
 ]

--- a/core1/Cargo.lock
+++ b/core1/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "micromath",
  "panic-probe",
  "rand_core",
+ "shared",
  "static_cell",
  "stm32-fmc",
  "stm32h7hal-ext",
@@ -220,7 +221,6 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -237,7 +237,6 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -251,7 +250,6 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.4.1"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -262,12 +260,10 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -278,7 +274,6 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
 ]
@@ -286,7 +281,6 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "bit_field",
  "bitflags 2.5.0",
@@ -330,7 +324,6 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -343,7 +336,6 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -361,7 +353,6 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "document-features",
 ]
@@ -369,12 +360,10 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/esrlabs/embassy?branch=feature/HSEM_SPI_FIX#a0fd477e9bc2e25a11c8d40f287ba28b1d9c18ab"
 dependencies = [
  "defmt",
 ]
@@ -729,6 +718,10 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "shared"
+version = "0.1.0"
 
 [[package]]
 name = "stable_deref_trait"

--- a/core1/Cargo.toml
+++ b/core1/Cargo.toml
@@ -55,11 +55,13 @@ static_cell = "2"
 chrono = { version = "^0.4", default-features = false }
 
 stm32h7hal-ext = { version = "0.1.0", path = "../stm32h7hal-ext" }
-# [patch."https://github.com/esrlabs/embassy"]
-# embassy-stm32 = { path = "../../embassy/embassy-stm32" }
-# embassy-sync = { path = "../../embassy/embassy-sync" }
-# embassy-executor = { path = "../../embassy/embassy-executor" }
-# embassy-time = { path = "../../embassy/embassy-time" }
+shared = { version = "0.1.0", path = "../shared" }
+
+[patch."https://github.com/esrlabs/embassy"]
+embassy-stm32 = { path = "../../embassy/embassy-stm32" }
+embassy-sync = { path = "../../embassy/embassy-sync" }
+embassy-executor = { path = "../../embassy/embassy-executor" }
+embassy-time = { path = "../../embassy/embassy-time" }
 
 # cargo build/run
 [profile.dev]

--- a/core1/Cargo.toml
+++ b/core1/Cargo.toml
@@ -57,11 +57,11 @@ chrono = { version = "^0.4", default-features = false }
 stm32h7hal-ext = { version = "0.1.0", path = "../stm32h7hal-ext" }
 shared = { version = "0.1.0", path = "../shared" }
 
-[patch."https://github.com/esrlabs/embassy"]
-embassy-stm32 = { path = "../../embassy/embassy-stm32" }
-embassy-sync = { path = "../../embassy/embassy-sync" }
-embassy-executor = { path = "../../embassy/embassy-executor" }
-embassy-time = { path = "../../embassy/embassy-time" }
+# [patch."https://github.com/esrlabs/embassy"]
+# embassy-stm32 = { path = "../../embassy/embassy-stm32" }
+# embassy-sync = { path = "../../embassy/embassy-sync" }
+# embassy-executor = { path = "../../embassy/embassy-executor" }
+# embassy-time = { path = "../../embassy/embassy-time" }
 
 # cargo build/run
 [profile.dev]

--- a/core1/memory.x
+++ b/core1/memory.x
@@ -29,8 +29,8 @@ SECTIONS {
     *(.sram3 .sram3.*);
     . = ALIGN(4);
     } > SRAM3
-  .sram4 (NOLOAD) : ALIGN(4) {
-    *(.sram4 .sram4.*);
+  .shared (NOLOAD) : ALIGN(4) {
+    *(.sram4 .sram4.* .shared .shared.*);
     . = ALIGN(4);
     } > SRAM4
   .bsram (NOLOAD) : ALIGN(4) {

--- a/core1/src/main.rs
+++ b/core1/src/main.rs
@@ -71,6 +71,7 @@ async fn main(_spawner: Spawner) {
 
 async fn get_core1_blink_delay() -> u32 {
     let mut retry = 10;
+    #[allow(unused_assignments)]
     let mut delay = 250;
     while !get_global_hsem().lock(5).await && retry > 0 {
         Timer::after_micros(50).await;

--- a/core1/src/main.rs
+++ b/core1/src/main.rs
@@ -1,5 +1,7 @@
 #![no_std]
 #![no_main]
+#![feature(sync_unsafe_cell)]
+use core::cell::SyncUnsafeCell;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
@@ -7,16 +9,21 @@ use hal::{
     bind_interrupts,
     gpio::{Level, Output, Speed},
     hsem::{HardwareSemaphore, InterruptHandler},
-    peripherals,
+    peripherals::{self, HSEM},
 };
-
-use {defmt_rtt as _, embassy_stm32 as hal, panic_probe as _, stm32h7hal_ext as hal_ext};
+use {
+    defmt_rtt as _, embassy_stm32 as hal, panic_probe as _, shared as _, stm32h7hal_ext as hal_ext,
+};
 
 bind_interrupts!(
     struct Irqs {
         HSEM2 => InterruptHandler<peripherals::HSEM>;
     }
 );
+
+// SAFETY: This is safe because all access to the HSEM registers are atomic
+static HSEM_INSTANCE: SyncUnsafeCell<Option<HardwareSemaphore<'static, HSEM>>> =
+    SyncUnsafeCell::new(None);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -26,7 +33,9 @@ async fn main(_spawner: Spawner) {
 
     let p = embassy_stm32::init_core1(200_000_000);
 
-    let mut hsem = HardwareSemaphore::new(p.HSEM, Irqs);
+    let hsem = HardwareSemaphore::new(p.HSEM, Irqs);
+    // initialize global HSEM instance
+    unsafe { *HSEM_INSTANCE.get() = Some(hsem) };
 
     // Enable the Cortex-M4 ART Clock
     embassy_stm32::pac::RCC
@@ -34,26 +43,57 @@ async fn main(_spawner: Spawner) {
         .modify(|w| w.set_arten(true));
 
     let mut led_yellow = Output::new(p.PE1, Level::Low, Speed::Low);
-    let _ = hsem.one_step_lock(1);
-    let _ = hsem.one_step_lock(2);
+    let _ = get_global_hsem().one_step_lock(1);
+    let _ = get_global_hsem().one_step_lock(2);
 
     led_yellow.set_high();
     Timer::after_millis(2000).await;
-    hsem.unlock(1, 0);
+    get_global_hsem().unlock(1, 0);
     led_yellow.set_low();
 
     Timer::after_millis(1000).await;
 
     led_yellow.set_high();
     Timer::after_millis(2000).await;
-    hsem.unlock(2, 0);
+    get_global_hsem().unlock(2, 0);
     led_yellow.set_low();
     Timer::after_millis(2000).await;
     loop {
+        let _ = get_core1_blink_delay().await;
+        let delay_time = get_core1_blink_delay().await;
         led_yellow.set_high();
-        Timer::after_millis(250).await;
+        Timer::after_millis(delay_time as u64).await;
 
         led_yellow.set_low();
-        Timer::after_millis(250).await;
+        Timer::after_millis(delay_time as u64).await;
+    }
+}
+
+async fn get_core1_blink_delay() -> u32 {
+    let mut retry = 10;
+    let mut delay = 250;
+    while !get_global_hsem().lock(5).await && retry > 0 {
+        Timer::after_micros(50).await;
+        retry -= 1;
+    }
+    if retry > 0 {
+        unsafe {
+            delay = shared::MAILBOX[0];
+        }
+        get_global_hsem().unlock(5, 0);
+    } else {
+        // Core1 has asquired the semaphore and is
+        // not releasing it - crashed?
+        defmt::panic!("Failed to asquire semaphore 1");
+    }
+    delay
+}
+
+fn get_global_hsem() -> &'static mut HardwareSemaphore<'static, HSEM> {
+    unsafe {
+        match *HSEM_INSTANCE.get() {
+            Some(ref mut obj) => obj,
+            None => defmt::panic!("HardwareSemaphore was not initialized"),
+        }
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,16 @@
 #![no_std]
+#![feature(sync_unsafe_cell)]
+
+use core::cell::SyncUnsafeCell;
+
+#[link_section = ".shared"]
+#[export_name = "MAILBOX"]
+// The initial value is not written into memory, but needs to be
+// done to make the compiler happy
+pub static mut MAILBOX: [u32; 10] = [0; 10];
+// SAFETY: This is safe because all access to the HSEM registers are atomic
+//pub static MAILBOX: SyncUnsafeCell<[u32; 10]> = SyncUnsafeCell::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
 pub fn dummy() {
     // do nothing
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![feature(sync_unsafe_cell)]
 
-use core::cell::SyncUnsafeCell;
-
 #[link_section = ".shared"]
 #[export_name = "MAILBOX"]
 // The initial value is not written into memory, but needs to be

--- a/toolchain.toml
+++ b/toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "clippy", "llvm-tools"]
+targets = ["thumbv7em-none-eabihf"]
+profile = "minimal"


### PR DESCRIPTION
Add a global HSEM object per core. This allows to acquire multiple mutable references as the operations (lock, unlock) are atomic.

Add initial shared memory functionality. This is currently only the bar minimum. Core 0 communicates through shared memory with Core 1 and sets the delay time for the yellow LED which is managed by Core 1.